### PR TITLE
Harmonize src paths of template and copy source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ process. To do so, see the following config example:
     ...
     deploy_additional_templates:
       - { 
-        src: "templates/application.conf.j2", 
+        src: "application.conf.j2", 
         dest: "{{ deploy_dir_config }}/application.conf" 
       }
       - { 
-        src: "templates/logback.xml.j2", 
+        src: "logback.xml.j2", 
         dest: "{{ deploy_dir_config }}/logback.xml", 
         mode: "0600"
       }
@@ -109,7 +109,7 @@ process. To do so, see the following config example:
     ...
     deploy_additional_copy:
       - { 
-        src: "/path/to/file", 
+        src: "file", 
         dest: "{{ deploy_dir_app }}/file",
         mode: "0644" 
       }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -147,11 +147,11 @@ deploy_service_type: default
 
 deploy_service_name: "{{ deploy_app_name | lower }}-{{ deploy_instance_nr }}"
 
-deploy_service_upstart_template: "templates/service/upstart.conf.j2"
+deploy_service_upstart_template: "service/upstart.conf.j2"
 
 deploy_service_upstart_location: "/etc/init/{{ deploy_app_name | lower }}-{{ deploy_instance_nr }}.conf"
 
-deploy_service_systemd_template: "templates/service/systemd.service.j2"
+deploy_service_systemd_template: "service/systemd.service.j2"
 
 deploy_service_systemd_location: "/etc/systemd/system/{{ deploy_app_name | lower }}-{{ deploy_instance_nr }}.service"
 

--- a/tasks/additional.yml
+++ b/tasks/additional.yml
@@ -30,7 +30,7 @@
 - name: "Additional - Deploy copy files"
   become: yes
   become_user: "{{ deploy_app_user }}"
-  template:
+  copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     owner: "{{ item.user | default(deploy_app_user) }}"

--- a/tests/playbook/deploy.yml
+++ b/tests/playbook/deploy.yml
@@ -10,7 +10,7 @@
     deploy_app_user: "bot-user"
     deploy_app_group: "bot-group"
     deploy_additional_templates:
-      - { src: "templates/application.conf.j2", dest: "{{ deploy_dir_config }}/application.conf" }
-      - { src: "templates/logback.xml.j2", dest: "{{ deploy_dir_config }}/logback.xml", mode: 600 }
+      - { src: "application.conf.j2", dest: "{{ deploy_dir_config }}/application.conf" }
+      - { src: "logback.xml.j2", dest: "{{ deploy_dir_config }}/logback.xml", mode: 600 }
   roles:
     - { role: ../../../ansible-java-deployment }


### PR DESCRIPTION
Since ansible has a built-in mechanism to find files automatically if
placed correctly, use these ansible default paths:

- template-module: looks up "templates" directories
- copy-module: looks up "files" directories

Therefore, it is not necessary to provide the "files" or "templates"
directory in the src path or to define it absolutely.

Signed-off-by: Christian Harke <christian.harke@bluecare.ch>