### PR TITLE
Fix systemd service template

### DIFF
--- a/templates/service/systemd.service.j2
+++ b/templates/service/systemd.service.j2
@@ -21,8 +21,13 @@ After=multi-user.target
 
 [Service]
 Type=simple
-ExecStartPre=/bin/rm -f {{ deploy_dir_app }}/RUNNING_PID
+Restart=on-failure
+{% if deploy_log_stdout == True or deploy_log_stderr == True %}
+ExecStart=/bin/sh -c "{{ deploy_dir_app }}/{{ deploy_service_start_command }} {% if deploy_log_stdout == True %}1> {{ deploy_log_stdout_path }}{% endif %} {% if deploy_log_stderr == True %}2>{{ deploy_log_stderr_path }}{% endif %}"
+{% else %}
 ExecStart={{ deploy_dir_app }}/{{ deploy_service_start_command }}
+{% endif %}
+ExecStopPost=/bin/rm -f {{ deploy_dir_app }}/RUNNING_PID
 WorkingDirectory={{ deploy_dir_app }}
 User={{ deploy_app_user }}
 Group={{ deploy_app_group }}


### PR DESCRIPTION
- Remove the `RUNNING_PID` after service stop.

- Restart the service on failure (this will restart the application
  for example on out-of-memory errors)

- Honor the `deploy_log_stdout/stderr` variables