### PR TITLE
Add default value for service description variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -153,6 +153,8 @@ deploy_service_type: default
 
 deploy_service_name: "{{ deploy_app_name | lower }}-{{ deploy_instance_nr }}"
 
+deploy_service_description: "Service definition for {{ deploy_app_name }}"
+
 deploy_service_upstart_template: "service/upstart.conf.j2"
 
 deploy_service_upstart_location: "/etc/init/{{ deploy_app_name | lower }}-{{ deploy_instance_nr }}.conf"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,7 +142,7 @@ deploy_service_poststop_script: ""
 # If true, service will start at boot time
 deploy_start_at_boot_time: False
 
-# Which service wrapper / systemloader you want to use
+# Which service wrapper / system loader you want to use
 #
 # This can be default, upstart, systemd or none
 #
@@ -166,7 +166,7 @@ deploy_service_systemd_location: "/etc/systemd/system/{{ deploy_app_name | lower
 # Additional files
 ###############################################
 
-# Additionaly template files to deploy. See readme for usage instructions
+# Additional template files to deploy. See readme for usage instructions
 deploy_additional_templates: []
 
 deploy_additional_copy: []

--- a/templates/service/systemd.service.j2
+++ b/templates/service/systemd.service.j2
@@ -16,7 +16,7 @@
 
 
 [Unit]
-Description={{ app_description }}
+Description={{ deploy_service_description }}
 After=multi-user.target
 
 [Service]

--- a/templates/service/upstart.conf.j2
+++ b/templates/service/upstart.conf.j2
@@ -14,7 +14,7 @@
 #
 #########################################################################################################
 
-description "Upstart script for {{ deploy_service_name }}"
+description "{{ deploy_service_description }}"
 author "https://github.com/acme-software/ansible-java-deployment"
 version 1.0.1
 


### PR DESCRIPTION
When the definition of the variable `app_description` was missing,
ansible would complain and abort the execution of the playbook.

Although describing the service is surely recommended, it should not
be mandatory. Therefore a more or less reasonable default has been
defined which is used in the upstart and the systemd service
definitions.