### PR TITLE
Remove service registration check

### DIFF
--- a/tasks/service/systemd.yml
+++ b/tasks/service/systemd.yml
@@ -6,16 +6,7 @@
     src: "{{ deploy_service_systemd_template }}"
     dest: "{{ deploy_service_systemd_location }}"
 
-- name: "Service - Reload initctl config"
+- name: "Service - Reload systemctl config"
   become: true
-  command: systemctl daemon-reload
-
-- name: "Service - Check if registered in systemctl"
-  become: true
-  command: "systemctl list-unit-files | grep {{ deploy_service_name }}"
-  register: deploy_initctl_service_loaded
-
-- name: "Service - Ensure registered in initctl"
-  fail:
-    msg: "Service {{ }} was not registered. This could be due to a misconfiguration in the systemd template."
-  when: deploy_initctl_service_loaded == deploy_service_name
+  systemd:
+    daemon_reload: yes

--- a/tasks/service/upstart.yml
+++ b/tasks/service/upstart.yml
@@ -9,13 +9,3 @@
 - name: "Service - Reload initctl config"
   become: true
   command: initctl reload-configuration
-
-- name: "Service - Check if registered in initctl"
-  become: true
-  command: "initctl list | grep {{ deploy_service_name }}"
-  register: deploy_initctl_service_loaded
-
-- name: "Service - Ensure registered in initctl"
-  fail:
-    msg: "Service {{ }} was not registered. This could be due to a misconfiguration in the upstart template."
-  when: deploy_initctl_service_loaded == deploy_service_name


### PR DESCRIPTION
Since ansible's `service` module would fail with an explanatory error message when attempting to start the according service if it was not registered successfully, it should not hurt too much if the manual service registration check is omitted.

fixes #24