### PR TITLE
Fix permission denied error on creating additional directories

### DIFF
--- a/tasks/additional.yml
+++ b/tasks/additional.yml
@@ -40,7 +40,6 @@
 
 - name: "Additional - Create directories"
   become: yes
-  become_user: "{{ deploy_app_user }}"
   file:
     path: "{{ item.path }}"
     state: directory


### PR DESCRIPTION
The given `become_user` does not have permission to create the
additional directories in `/opt`, therefore it is sufficient even
when this parameter is dropped.