### PR TITLE
Fix initctl not found

### DIFF
--- a/tasks/service/upstart.yml
+++ b/tasks/service/upstart.yml
@@ -8,4 +8,4 @@
 
 - name: "Service - Reload initctl config"
   become: true
-  command: initctl reload-configuration
+  command: /sbin/initctl reload-configuration


### PR DESCRIPTION
On some machines, `initctl` seems to be not resolvable. Therefore, the
absolute path must be provided.