### PR TITLE
Add RHEL8 support

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -8,7 +8,7 @@
 
 - include_tasks: service/systemd.yml
   when: deploy_service_type == "systemd" or
-        (deploy_service_type == "default" and (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == '7')
+        (deploy_service_type == "default" and (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version >= '7')
 
 - name: "Service - Ensure {{ deploy_service_name }} starts on boot"
   become: yes


### PR DESCRIPTION
Service setup did not properly detect the service type when using a
distribution with major version greater than `7`. This now defaults
automatically to `systemd`.