### PR TITLE
Do not truncate stderr and stdout logs on application start

### DIFF
--- a/templates/service/systemd.service.j2
+++ b/templates/service/systemd.service.j2
@@ -23,7 +23,7 @@ After=multi-user.target
 Type=simple
 Restart=on-failure
 {% if deploy_log_stdout == True or deploy_log_stderr == True %}
-ExecStart=/bin/sh -c "{{ deploy_dir_app }}/{{ deploy_service_start_command }} {% if deploy_log_stdout == True %}1> {{ deploy_log_stdout_path }}{% endif %} {% if deploy_log_stderr == True %}2>{{ deploy_log_stderr_path }}{% endif %}"
+ExecStart=/bin/sh -c "{{ deploy_dir_app }}/{{ deploy_service_start_command }} {% if deploy_log_stdout == True %}1>> {{ deploy_log_stdout_path }}{% endif %} {% if deploy_log_stderr == True %}2>> {{ deploy_log_stderr_path }}{% endif %}"
 {% else %}
 ExecStart={{ deploy_dir_app }}/{{ deploy_service_start_command }}
 {% endif %}

--- a/templates/service/upstart.conf.j2
+++ b/templates/service/upstart.conf.j2
@@ -47,7 +47,7 @@ end script
 {% endif %}
 
 # Execute deploy_service_start_command and log stdout
-exec su -s /bin/sh -c 'exec "$0" "$@" {% if deploy_log_stdout == True %}1>>{{ deploy_log_stdout_path }}{% endif %} {% if deploy_log_stderr == True %}2>>{{ deploy_log_stderr_path }}{% endif %}' {{ deploy_app_user }} -- {{ deploy_service_start_command }} -b wibble
+exec su -s /bin/sh -c 'exec "$0" "$@" {% if deploy_log_stdout == True %}1>> {{ deploy_log_stdout_path }}{% endif %} {% if deploy_log_stderr == True %}2>> {{ deploy_log_stderr_path }}{% endif %}' {{ deploy_app_user }} -- {{ deploy_service_start_command }} -b wibble
 
 {% if deploy_service_has_prestop_script == True %}
 # Pre-Stop Script


### PR DESCRIPTION
Currently, SystemD managed apps are losing their stdout and sterr logs when the process is restarted. Thus, it is possible to lose important information about why the process was exited.